### PR TITLE
GH-635 Enable eclipselink, add postgres jdbc driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # Use a non-docker-io registry, because pulling images from docker.io is
 # subject to aggressive request rate limiting and bandwidth shaping.
 FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1726695192 AS build
-ARG ECLIPSELINK=false
+ARG ECLIPSELINK=true
 ARG ECLIPSELINK_DEPS
 
 # Copy the REST catalog into the container

--- a/extension/persistence/eclipselink/build.gradle.kts
+++ b/extension/persistence/eclipselink/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     }
   }
 
+  runtimeOnly("org.postgresql:postgresql:42.7.4")
   compileOnly(libs.jetbrains.annotations)
 
   testImplementation(libs.h2)


### PR DESCRIPTION
Enable persistence
- Enable EclipseLink to connect to Postgres
- Add Postgres JDBC driver to runtime dependencies