### PR TITLE
GH-635 Add build and push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,95 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Publish Polaris Server
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      # Get the current date in YYYY-mm-dd format to be used as the image tag
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+        env:
+          ORG_GRADLE_PROJECT_mavenUser: ${{ secrets.JFROG_USER }}
+          ORG_GRADLE_PROJECT_mavenPassword: ${{ secrets.JFROG_TOKEN }}
+          ORG_GRADLE_PROJECT_snapshotsRepoURL: ${{ vars.MAVEN_SNAPSHOT_URL }}
+          ORG_GRADLE_PROJECT_releasesRepoURL: ${{ vars.MAVEN_RELEASE_URL }}
+      # The following two steps are needed to enable multi-platform Docker builds
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY }}
+          username: ${{ secrets.JFROG_USER }}
+          password: ${{ secrets.JFROG_TOKEN }}
+      - name: Set Docker Metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ vars.CONTAINER_REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=sha
+            type=raw,value=${{ steps.date.outputs.date }}
+      - name: Docker Build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+


### PR DESCRIPTION
This workflow triggers on each push to the `main` branch, and builds and uploads a custom Polaris Server Docker image to JFrog artifactory, tagged by the date of upload in `YYYY-mm-dd` format.

My testing showed the runtime to be around 25m, which seems really long to me. There are many lines printed during the docker build saying "caching not enabled" though I have tried to turn it on. @David-N-Perkins could you please check if my caching part is right? I adapted it from workflows in data-processing.